### PR TITLE
Use replaceState to change query string based on filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,15 +18,15 @@
 <main>
   <div class="sidebar box">
     <div class="separated">
-      <input class="search-input" type="text" placeholder="Search displayed bugs" />
+      <input class="search-input" name="search" type="text" placeholder="Search displayed bugs" />
     </div>
     <ul class="filter-list filters separated">
       <li>
-        <input id="good-first" type="checkbox" value="good-first" checked />
+        <input id="good-first" name="easy" type="checkbox" value="good-first" checked />
         <label for="good-first">Good first bugs</label>
       </li>
       <li>
-        <input id="mentored" type="checkbox" value="mentored" />
+        <input id="mentored" name="mentored" type="checkbox" value="mentored" />
         <label for="mentored">Mentored bugs</label>
       </li>
     </ul>


### PR DESCRIPTION
fixes #30 

in order to append query parameters on url, browser needs to be refreshed. I can add hash parameters but it will generate two parameters interface.
What I think to fix this problem is add an export filter button to generate a url with the filters and process what's missing to get from query string.

Let me know if I should improve something.
