### PR TITLE
added fixed position to header

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,9 +95,9 @@ main {
 }
 
 .main {
-  margin: 0px auto;
+  display: flex;
+  margin: 0px 190px;
   box-sizing: border-box;
-  width: 68%;
 }
 
 .footer {

--- a/style.css
+++ b/style.css
@@ -75,22 +75,29 @@ header {
 }
 
 main {
+  position: relative;
   margin: 2em;
-  flex-grow: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  display: block;
+  padding-top: 30px;
+}
+
+.sidebar:last-child {
+  top: 55px;
+  right: 20px;
 }
 
 .sidebar {
+  position: fixed;
   width: 170px;
+  margin: 0px 0.2em;
   font-size: .9em;
   flex-shrink: 0;
 }
 
 .main {
-  margin: 0 2em;
-  flex-grow: 1;
+  margin: 0px auto;
+  box-sizing: border-box;
+  width: 68%;
 }
 
 .footer {
@@ -104,9 +111,12 @@ main {
 /* Header */
 
 header.box {
-  position: relative;
+  position: fixed;
+  width: 100%;
   border-radius: 0;
   border-width: 0 0 1px 0;
+  z-index: 1;
+  box-sizing: border-box;
 }
 
 header span {
@@ -358,12 +368,17 @@ header .links li:first-child {
 
   main {
     margin: 0;
+    display: flex;
+    padding-top: 40px;
     flex-direction: column;
   }
 
-  .sidebar, .main {
+  .sidebar, .sidebar:last-child, .main {
+    position: relative;
     width: 100%;
     margin: 0;
+    top: 0;
+    right: 0;
     border-radius: 0px;
   }
 

--- a/style.css
+++ b/style.css
@@ -77,17 +77,17 @@ header {
 main {
   position: relative;
   margin: 2em;
-  display: block;
-  padding-top: 30px;
+  display: flex;
+  align-items: flex-start;
 }
 
-.sidebar:last-child {
-  top: 55px;
-  right: 20px;
+.main ul {
+  width: 100%;
 }
 
 .sidebar {
-  position: fixed;
+  position: sticky;
+  top: 55px;
   width: 170px;
   margin: 0px 0.2em;
   font-size: .9em;
@@ -96,8 +96,10 @@ main {
 
 .main {
   display: flex;
-  margin: 0px 190px;
+  justify-content: center;
+  flex-grow: 1;
   box-sizing: border-box;
+  margin: 0 2em;
 }
 
 .footer {
@@ -111,8 +113,8 @@ main {
 /* Header */
 
 header.box {
-  position: fixed;
-  width: 100%;
+  position: sticky;
+  top: 0;
   border-radius: 0;
   border-width: 0 0 1px 0;
   z-index: 1;
@@ -369,11 +371,10 @@ header .links li:first-child {
   main {
     margin: 0;
     display: flex;
-    padding-top: 40px;
     flex-direction: column;
   }
 
-  .sidebar, .sidebar:last-child, .main {
+  .sidebar, .main {
     position: relative;
     width: 100%;
     margin: 0;


### PR DESCRIPTION
![captura de tela_2017-03-06_16-33-54](https://cloud.githubusercontent.com/assets/11761724/23626296/1ce38400-028b-11e7-8b37-cc61e4f90b7e.png)

The header now has a fixed position, the loader icon is always visible.

fixes #7 