### PR TITLE
Update links

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 <header class="box header">
   <span onclick="document.body.classList.toggle('dark')">Firefox Developer Tools</span>
   <ul class="links">
-    <li><a href="https://wiki.mozilla.org/DevTools/GetInvolved" target="_blank">How to contribute?</a></li>
-    <li><a href="https://dxr.mozilla.org/mozilla-central/source/devtools" target="_blank">Browse the code</a></li>
+    <li><a href="https://firefox-dev.tools/#getting-in-touch" target="_blank">How to contribute?</a></li>
+    <li><a href="https://github.com/devtools-html" target="_blank">Browse the code</a></li>
     <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=Developer%20Tools" target="_blank">File a bug</a></li>
     <li><a href="https://twitter.com/firefoxdevtools" target="_blank">Twitter</a></li>
   </ul>


### PR DESCRIPTION
How to Contribute page has moved
Point to the github page with a more user/dev friendly interface

The second link still works so not sure which one is more relevant. Let me know if you want to keep only the first change.